### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Laravel SDK to conveniently access the [WorkOS API](https://workos.com).
 
+For more information on our API and WorkOS, check out our docs [here](https://docs.workos.com).
+
 ## Installation
 
 To install via composer, run the following:
@@ -19,7 +21,6 @@ For Laravel 5.0-5.4, add the WorkOS ServiceProvider in your `config/app.php`:
 
 For Laravel 5.5 and up, 6.x and 7.x... you're all set!
 
-
 ## Getting Started
 
 Create a WorkOS configuration file by running the following:
@@ -30,23 +31,6 @@ php artisan vendor:publish --provider="WorkOS\Laravel\WorkOSServiceProvider"
 The package will need to be configured with your [api key](https://dashboard.workos.com/api-keys) and [project id](https://dashboard.workos.com/sso/configuration).
 By default, the package will look for a `WORKOS_API_KEY` and `WORKOS_PROJECT_ID` environment variable.
 
-### SSO
-The package offers the following convenience functions to utilize WorkOS SSO.
+## Usage
 
-First we'll want to generate an OAuth 2.0 Authorization URL to initiate the SSO workflow with:
-
-```php
-$url = (new \WorkOS\SSO())->getAuthorizationUrl(
-    'foo-corp.com',
-    'http://my.cool.co/auth/callback',
-    ['things' => 'gonna get this back'],
-    null // Pass along provider if we don't have a domain
-);
-```
-
-After directing the user to the Authorization URL and successfully completing the SSO workflow, use 
-the code passed back from WorkOS to grab the profile of the authenticated user to verify all is good:
-
-```php
-$profile = (new \WorkOS\SSO())->getProfile($code);
-```
+Underneath it all, the Laravel SDK utilizes the WorkOS PHP SDK. For more information on usage, check out the docs [here](https://docs.workos.com/sdk/laravel) and the PHP SDK [here](https://github.com/workos-inc/workos-php).

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.6.0",
     "illuminate/support": "^5.0 || ^6.0 || ^7.0",
-    "workos/workos-php": "0.0.1"
+    "workos/workos-php": "0.3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WorkOS\Laravel;
+
+final class Version
+{
+    const SDK_IDENTIFIER = "WorkOS PHP Laravel";
+    const SDK_VERSION = '0.3.0';
+}

--- a/lib/WorkOSServiceProvider.php
+++ b/lib/WorkOSServiceProvider.php
@@ -31,6 +31,8 @@ class WorkOSServiceProvider extends ServiceProvider
         $config = $this->app["config"]->get("workos");
         \WorkOS\WorkOS::setApiKey($config["api_key"]);
         \WorkOS\WorkOS::setProjectId($config["project_id"]);
+        \WorkOS\WorkOS::setIdentifier(\WorkOS\Laravel\Version::SDK_IDENTIFIER);
+        \WorkOS\WorkOS::setVersion(\WorkOS\Laravel\Version::SDK_VERSION);
 
         if ($config["api_base_url"]) {
             \WorkOS\WorkOS::setApiBaseUrl($config["api_base_url"]);


### PR DESCRIPTION
# Overview
Bump this as the base SDK has been bumped. There is an API to set the identifier and version that is available in the new base SDK that'll in turn produce a user agent in api calls to the WorkOS api that reflect which SDK it's coming from.

<img width="498" alt="Screen Shot 2020-04-28 at 1 15 47 AM" src="https://user-images.githubusercontent.com/19150308/80449715-d4f9f880-88ed-11ea-8545-86feb64eecf6.png">
