### PR TITLE
Bump `workos-php` Version to `0.7.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,15 @@
- {
+{
   "name": "workos/workos-php-laravel",
   "description": "WorkOS PHP Library for Laravel",
-  "keywords": ["laravel", "laravel 5", "laravel 6", "laravel 7", "workos", "sdk", "sso"],
+  "keywords": [
+    "laravel",
+    "laravel 5",
+    "laravel 6",
+    "laravel 7",
+    "workos",
+    "sdk",
+    "sso"
+  ],
   "license": "MIT",
   "authors": [
     {
@@ -12,7 +20,7 @@
   "require": {
     "php": ">=5.6.0",
     "illuminate/support": "^5.0 || ^6.0 || ^7.0",
-    "workos/workos-php": "0.6.0"
+    "workos/workos-php": "0.7.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",

--- a/lib/Version.php
+++ b/lib/Version.php
@@ -5,5 +5,5 @@ namespace WorkOS\Laravel;
 final class Version
 {
     const SDK_IDENTIFIER = "WorkOS PHP Laravel";
-    const SDK_VERSION = '0.6.0';
+    const SDK_VERSION = '0.7.0';
 }


### PR DESCRIPTION
This PR updates the `workos-php` dependency to version `0.7.0` to provide access to the `connection_id` attribute in Profile objects.

[Related `workos-php` PR](https://github.com/workos-inc/workos-php/pull/16)