### PR TITLE
Bump `workos/workos-php` version to `1.3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": ">=5.6.0",
     "illuminate/support": "^5.0 || ^6.0 || ^7.0 || ^8.0",
-    "workos/workos-php": "1.0.0"
+    "workos/workos-php": "1.3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15",


### PR DESCRIPTION
Bumps the version of `workos/workos-php` to the latest version.