### PR TITLE
feat: add Facade, improve performance and ergonomics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,14 @@
   ],
   "require": {
     "php": ">=8.1.0",
+    "illuminate/contracts": "^11.0|^12.0",
+    "illuminate/support": "^11.0|^12.0",
     "workos/workos-php": "^v4.29.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.15 || ^3.6",
-    "phpunit/phpunit": "^5.7 || ^10.1"
+    "phpunit/phpunit": "^5.7 || ^10.1",
+    "orchestra/testbench": "^9.0|^10.0"
   },
   "suggest": {
     "laravel/framework": "For testing"
@@ -31,7 +34,10 @@
   "autoload": {
     "psr-4": {
       "WorkOS\\Laravel\\": "lib/"
-    }
+    },
+    "files": [
+      "lib/helpers.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {
@@ -45,7 +51,10 @@
     "laravel": {
       "providers": [
         "WorkOS\\Laravel\\WorkOSServiceProvider"
-      ]
+      ],
+      "aliases": {
+        "WorkOS": "WorkOS\\Laravel\\Facades\\WorkOS"
+      }
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,14 @@
   ],
   "require": {
     "php": ">=8.1.0",
-    "illuminate/contracts": "^11.0|^12.0",
-    "illuminate/support": "^11.0|^12.0",
+    "illuminate/contracts": "^10.0|^11.0|^12.0",
+    "illuminate/support": "^10.0|^11.0|^12.0",
     "workos/workos-php": "^v4.29.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.15 || ^3.6",
-    "phpunit/phpunit": "^5.7 || ^10.1",
-    "orchestra/testbench": "^9.0|^10.0"
+    "friendsofphp/php-cs-fixer": "^3.64",
+    "phpunit/phpunit": "^10.1 || ^11.0",
+    "orchestra/testbench": "^8.0|^9.0|^10.0"
   },
   "suggest": {
     "laravel/framework": "For testing"

--- a/lib/Facades/WorkOS.php
+++ b/lib/Facades/WorkOS.php
@@ -11,9 +11,13 @@ use Illuminate\Support\Facades\Facade;
  * @method static \WorkOS\DirectorySync directorySync()
  * @method static \WorkOS\MFA mfa()
  * @method static \WorkOS\Organizations organizations()
+ * @method static \WorkOS\Passwordless passwordless()
  * @method static \WorkOS\Portal portal()
  * @method static \WorkOS\SSO sso()
  * @method static \WorkOS\UserManagement userManagement()
+ * @method static \WorkOS\Vault vault()
+ * @method static \WorkOS\Webhook webhook()
+ * @method static \WorkOS\Widgets widgets()
  *
  * @see \WorkOS\Laravel\WorkOSService
  */

--- a/lib/Facades/WorkOS.php
+++ b/lib/Facades/WorkOS.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkOS\Laravel\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static \WorkOS\AuditLogs auditLogs()
+ * @method static \WorkOS\DirectorySync directorySync()
+ * @method static \WorkOS\MFA mfa()
+ * @method static \WorkOS\Organizations organizations()
+ * @method static \WorkOS\Portal portal()
+ * @method static \WorkOS\SSO sso()
+ * @method static \WorkOS\UserManagement userManagement()
+ *
+ * @see \WorkOS\Laravel\WorkOSService
+ */
+class WorkOS extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'workos';
+    }
+}

--- a/lib/Facades/WorkOS.php
+++ b/lib/Facades/WorkOS.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \WorkOS\Organizations organizations()
  * @method static \WorkOS\Passwordless passwordless()
  * @method static \WorkOS\Portal portal()
+ * @method static \WorkOS\RBAC rbac()
  * @method static \WorkOS\SSO sso()
  * @method static \WorkOS\UserManagement userManagement()
  * @method static \WorkOS\Vault vault()

--- a/lib/Facades/WorkOS.php
+++ b/lib/Facades/WorkOS.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \WorkOS\Webhook webhook()
  * @method static \WorkOS\Widgets widgets()
  *
- * @see \WorkOS\Laravel\WorkOSService
+ * @see \WorkOS\Laravel\Services\WorkOSService
  */
 class WorkOS extends Facade
 {

--- a/lib/Services/WorkOSService.php
+++ b/lib/Services/WorkOSService.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WorkOS\Laravel\Services;
+
+use InvalidArgumentException;
+use WorkOS\AuditLogs;
+use WorkOS\DirectorySync;
+use WorkOS\MFA;
+use WorkOS\Organizations;
+use WorkOS\Portal;
+use WorkOS\SSO;
+use WorkOS\UserManagement;
+
+/**
+ * A singleton class that provides a fluent interface for accessing WorkOS services
+ * in a Laravel Application.
+ *
+ * @method \WorkOS\AuditLogs auditLogs()
+ * @method \WorkOS\DirectorySync directorySync()
+ * @method \WorkOS\MFA mfa()
+ * @method \WorkOS\Organizations organizations()
+ * @method \WorkOS\Portal portal()
+ * @method \WorkOS\SSO sso()
+ * @method \WorkOS\UserManagement userManagement()
+ */
+class WorkOSService
+{
+    /**
+     * The array of cached service instances
+     *
+     * @var array
+     */
+    private $instances = [];
+
+    /**
+     * Map of supported services to their class names
+     *
+     * @var array
+     */
+    private $serviceMap = [
+        'auditLogs' => AuditLogs::class,
+        'directorySync' => DirectorySync::class,
+        'mfa' => MFA::class,
+        'organizations' => Organizations::class,
+        'portal' => Portal::class,
+        'sso' => SSO::class,
+        'userManagement' => UserManagement::class,
+    ];
+
+    /**
+     * Dynamically resolve a WorkOS service.
+     *
+     * @param  string  $name
+     * @param  array  $arguments
+     * @return mixed
+     */
+    public function __call($name, $arguments)
+    {
+        if (! array_key_exists($name, $this->serviceMap)) {
+            throw new InvalidArgumentException("WorkOS service [$name] is not supported.");
+        }
+
+        if (isset($this->instances[$name])) {
+            return $this->instances[$name];
+        }
+
+        return $this->instances[$name] = $arguments ? new $this->serviceMap[$name]($arguments) : new $this->serviceMap[$name];
+    }
+}

--- a/lib/Services/WorkOSService.php
+++ b/lib/Services/WorkOSService.php
@@ -9,9 +9,13 @@ use WorkOS\AuditLogs;
 use WorkOS\DirectorySync;
 use WorkOS\MFA;
 use WorkOS\Organizations;
+use WorkOS\Passwordless;
 use WorkOS\Portal;
 use WorkOS\SSO;
 use WorkOS\UserManagement;
+use WorkOS\Vault;
+use WorkOS\Webhook;
+use WorkOS\Widgets;
 
 /**
  * A singleton class that provides a fluent interface for accessing WorkOS services
@@ -21,9 +25,13 @@ use WorkOS\UserManagement;
  * @method \WorkOS\DirectorySync directorySync()
  * @method \WorkOS\MFA mfa()
  * @method \WorkOS\Organizations organizations()
+ * @method \WorkOS\Passwordless passwordless()
  * @method \WorkOS\Portal portal()
  * @method \WorkOS\SSO sso()
  * @method \WorkOS\UserManagement userManagement()
+ * @method \WorkOS\Vault vault()
+ * @method \WorkOS\Webhook webhook()
+ * @method \WorkOS\Widgets widgets()
  */
 class WorkOSService
 {
@@ -44,9 +52,13 @@ class WorkOSService
         'directorySync' => DirectorySync::class,
         'mfa' => MFA::class,
         'organizations' => Organizations::class,
+        'passwordless' => Passwordless::class,
         'portal' => Portal::class,
         'sso' => SSO::class,
         'userManagement' => UserManagement::class,
+        'vault' => Vault::class,
+        'webhook' => Webhook::class,
+        'widgets' => Widgets::class,
     ];
 
     /**

--- a/lib/Services/WorkOSService.php
+++ b/lib/Services/WorkOSService.php
@@ -11,6 +11,7 @@ use WorkOS\MFA;
 use WorkOS\Organizations;
 use WorkOS\Passwordless;
 use WorkOS\Portal;
+use WorkOS\RBAC;
 use WorkOS\SSO;
 use WorkOS\UserManagement;
 use WorkOS\Vault;
@@ -27,6 +28,7 @@ use WorkOS\Widgets;
  * @method \WorkOS\Organizations organizations()
  * @method \WorkOS\Passwordless passwordless()
  * @method \WorkOS\Portal portal()
+ * @method \WorkOS\RBAC rbac()
  * @method \WorkOS\SSO sso()
  * @method \WorkOS\UserManagement userManagement()
  * @method \WorkOS\Vault vault()
@@ -54,6 +56,7 @@ class WorkOSService
         'organizations' => Organizations::class,
         'passwordless' => Passwordless::class,
         'portal' => Portal::class,
+        'rbac' => RBAC::class,
         'sso' => SSO::class,
         'userManagement' => UserManagement::class,
         'vault' => Vault::class,

--- a/lib/Services/WorkOSService.php
+++ b/lib/Services/WorkOSService.php
@@ -78,6 +78,6 @@ class WorkOSService
             return $this->instances[$name];
         }
 
-        return $this->instances[$name] = $arguments ? new $this->serviceMap[$name]($arguments) : new $this->serviceMap[$name];
+        return $this->instances[$name] = $arguments ? new $this->serviceMap[$name](...$arguments) : new $this->serviceMap[$name];
     }
 }

--- a/lib/WorkOSServiceProvider.php
+++ b/lib/WorkOSServiceProvider.php
@@ -1,8 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WorkOS\Laravel;
 
 use Illuminate\Support\ServiceProvider;
+use WorkOS\Laravel\Services\WorkOSService;
 
 /**
  * Class WorkOSServiceProvider.
@@ -12,11 +15,12 @@ class WorkOSServiceProvider extends ServiceProvider
     /**
      * Bootstrap the ServiceProvider.
      */
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->publishes(
-                [__DIR__."/../config/workos.php" => config_path("workos.php")]
+                [__DIR__.'/../config/workos.php' => config_path('workos.php')],
+                'workos-config'
             );
         }
     }
@@ -24,18 +28,29 @@ class WorkOSServiceProvider extends ServiceProvider
     /**
      * Register the ServiceProvider as well as setup WorkOS.
      */
-    public function register()
+    public function register(): void
     {
-        $this->mergeConfigFrom(__DIR__."/../config/workos.php", "workos");
+        $this->mergeConfigFrom(__DIR__.'/../config/workos.php', 'workos');
 
-        $config = $this->app["config"]->get("workos");
-        \WorkOS\WorkOS::setApiKey($config["api_key"]);
-        \WorkOS\WorkOS::setClientId($config["client_id"]);
-        \WorkOS\WorkOS::setIdentifier(\WorkOS\Laravel\Version::SDK_IDENTIFIER);
-        \WorkOS\WorkOS::setVersion(\WorkOS\Laravel\Version::SDK_VERSION);
+        // Ensures that the WorkOS service is configured only once, rather than every request
+        $this->app->singleton('workos', function ($app) {
+            $config = $app['config']->get('workos');
 
-        if ($config["api_base_url"]) {
-            \WorkOS\WorkOS::setApiBaseUrl($config["api_base_url"]);
-        }
+            \WorkOS\WorkOS::setApiKey($config['api_key']);
+            \WorkOS\WorkOS::setClientId($config['client_id']);
+            \WorkOS\WorkOS::setIdentifier(Version::SDK_IDENTIFIER);
+            \WorkOS\WorkOS::setVersion(Version::SDK_VERSION);
+
+            if ($config['api_base_url']) {
+                \WorkOS\WorkOS::setApiBaseUrl($config['api_base_url']);
+            }
+
+            return new WorkOSService;
+        });
+
+        // Allows for dependency injection (e.g. `show(WorkOSService $service)`)
+        // while still ensuring we're using the configured singleton rather than
+        // potentially generating a new, unconfigured version of the singleton
+        $this->app->alias('workos', WorkOSService::class);
     }
 }

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use WorkOS\Laravel\Services\WorkOSService;
+
+if (! function_exists('workos')) {
+    /**
+     * Access the WorkOS Manager.
+     *
+     * @return \WorkOS\Laravel\WorkOSManager
+     */
+    function workos()
+    {
+        return app(WorkOSService::class);
+    }
+}

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -8,7 +8,7 @@ if (! function_exists('workos')) {
     /**
      * Access the WorkOS Manager.
      *
-     * @return \WorkOS\Laravel\WorkOSManager
+     * @return \WorkOS\Laravel\Services\WorkOSService
      */
     function workos()
     {

--- a/tests/WorkOS/WorkOSFacadeTest.php
+++ b/tests/WorkOS/WorkOSFacadeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WorkOS\Laravel;
+
+use WorkOS\Laravel\Facades\WorkOS;
+use WorkOS\Laravel\Services\WorkOSService;
+
+class WorkOSFacadeTest extends LaravelTestCase
+{
+    protected $app;
+
+    protected function setUp(): void
+    {
+        $this->app = $this->setupApplication();
+        $this->setDefaultConfig();
+        $this->setupProvider($this->app);
+    }
+
+    protected function setDefaultConfig(array $overrides = []): void
+    {
+        $defaults = [
+            'api_key' => 'pk_test',
+            'client_id' => 'client_test',
+        ];
+
+        foreach (array_merge($defaults, $overrides) as $key => $value) {
+            $this->app['config']->set("workos.{$key}", $value);
+        }
+    }
+
+    public function test_facade_resolves_workos_service()
+    {
+        WorkOS::setFacadeApplication($this->app);
+
+        $this->assertInstanceOf(\WorkOS\UserManagement::class, WorkOS::userManagement());
+    }
+
+    public function test_facade_provides_access_to_all_services()
+    {
+        WorkOS::setFacadeApplication($this->app);
+
+        $this->assertInstanceOf(\WorkOS\AuditLogs::class, WorkOS::auditLogs());
+        $this->assertInstanceOf(\WorkOS\DirectorySync::class, WorkOS::directorySync());
+        $this->assertInstanceOf(\WorkOS\MFA::class, WorkOS::mfa());
+        $this->assertInstanceOf(\WorkOS\Organizations::class, WorkOS::organizations());
+        $this->assertInstanceOf(\WorkOS\Portal::class, WorkOS::portal());
+        $this->assertInstanceOf(\WorkOS\SSO::class, WorkOS::sso());
+        $this->assertInstanceOf(\WorkOS\UserManagement::class, WorkOS::userManagement());
+    }
+}

--- a/tests/WorkOS/WorkOSFacadeTest.php
+++ b/tests/WorkOS/WorkOSFacadeTest.php
@@ -39,12 +39,14 @@ class WorkOSFacadeTest extends LaravelTestCase
     {
         WorkOS::setFacadeApplication($this->app);
 
-        $this->assertInstanceOf(\WorkOS\AuditLogs::class, WorkOS::auditLogs());
-        $this->assertInstanceOf(\WorkOS\DirectorySync::class, WorkOS::directorySync());
-        $this->assertInstanceOf(\WorkOS\MFA::class, WorkOS::mfa());
-        $this->assertInstanceOf(\WorkOS\Organizations::class, WorkOS::organizations());
-        $this->assertInstanceOf(\WorkOS\Portal::class, WorkOS::portal());
-        $this->assertInstanceOf(\WorkOS\SSO::class, WorkOS::sso());
-        $this->assertInstanceOf(\WorkOS\UserManagement::class, WorkOS::userManagement());
+        $service = new WorkOSService();
+        $reflection = new \ReflectionClass($service);
+        $property = $reflection->getProperty('serviceMap');
+        $property->setAccessible(true);
+        $serviceMap = $property->getValue($service);
+
+        foreach ($serviceMap as $method => $class) {
+            $this->assertInstanceOf($class, WorkOS::$method(), "Facade method {$method}() should return an instance of {$class}");
+        }
     }
 }

--- a/tests/WorkOS/WorkOSServiceProviderTest.php
+++ b/tests/WorkOS/WorkOSServiceProviderTest.php
@@ -70,9 +70,13 @@ class WorkOSServiceProviderTest extends LaravelTestCase
         $this->assertInstanceOf(\WorkOS\DirectorySync::class, $service->directorySync());
         $this->assertInstanceOf(\WorkOS\MFA::class, $service->mfa());
         $this->assertInstanceOf(\WorkOS\Organizations::class, $service->organizations());
+        $this->assertInstanceOf(\WorkOS\Passwordless::class, $service->passwordless());
         $this->assertInstanceOf(\WorkOS\Portal::class, $service->portal());
         $this->assertInstanceOf(\WorkOS\SSO::class, $service->sso());
         $this->assertInstanceOf(\WorkOS\UserManagement::class, $service->userManagement());
+        $this->assertInstanceOf(\WorkOS\Vault::class, $service->vault());
+        $this->assertInstanceOf(\WorkOS\Webhook::class, $service->webhook());
+        $this->assertInstanceOf(\WorkOS\Widgets::class, $service->widgets());
     }
 
     public function test_workos_service_caches_service_instances()
@@ -101,5 +105,57 @@ class WorkOSServiceProviderTest extends LaravelTestCase
         $this->app->make('workos');
 
         $this->assertEquals('https://custom-api.workos.com/', \WorkOS\WorkOS::getApiBaseUrl());
+    }
+
+    public function test_service_map_includes_all_available_workos_services()
+    {
+        // Discover available services from the WorkOS PHP SDK
+        $libPath = __DIR__ . '/../../vendor/workos/workos-php/lib';
+        $availableServices = [];
+
+        if (!is_dir($libPath)) {
+            $this->markTestSkipped('WorkOS PHP SDK vendor directory not found at: ' . $libPath);
+        }
+
+        foreach (glob($libPath . '/*.php') as $file) {
+            $className = basename($file, '.php');
+
+            // Skip utility classes that aren't services
+            if (in_array($className, ['WorkOS', 'Client', 'Version', 'Resource'])) {
+                continue;
+            }
+
+            // Convert class name to camelCase method name
+            // Special handling for acronyms: MFA -> mfa, SSO -> sso
+            // Note: Str::camel() doesn't work for all-caps (MFA -> mFA, not mfa)
+            if (ctype_upper($className)) {
+                $methodName = strtolower($className);
+            } else {
+                $methodName = lcfirst($className);
+            }
+            $availableServices[$methodName] = "WorkOS\\{$className}";
+        }
+
+        // Get the actual service map from WorkOSService using reflection
+        $service = workos();
+        $reflection = new \ReflectionClass($service);
+        $property = $reflection->getProperty('serviceMap');
+        $property->setAccessible(true);
+        $actualServiceMap = $property->getValue($service);
+
+        // Compare available services with mapped services
+        $missingServices = array_diff_key($availableServices, $actualServiceMap);
+        $extraServices = array_diff_key($actualServiceMap, $availableServices);
+
+        $errorMessage = '';
+        if (!empty($missingServices)) {
+            $errorMessage .= 'Missing services in WorkOSService::$serviceMap: ' . implode(', ', array_keys($missingServices)) . '. ';
+        }
+        if (!empty($extraServices)) {
+            $errorMessage .= 'Extra services in WorkOSService::$serviceMap: ' . implode(', ', array_keys($extraServices)) . '.';
+        }
+
+        $this->assertEmpty($missingServices + $extraServices, $errorMessage);
+        $this->assertEquals($availableServices, $actualServiceMap, 'Service map should match available WorkOS services');
     }
 }

--- a/tests/WorkOS/WorkOSServiceProviderTest.php
+++ b/tests/WorkOS/WorkOSServiceProviderTest.php
@@ -2,6 +2,8 @@
 
 namespace WorkOS\Laravel;
 
+use WorkOS\Laravel\Services\WorkOSService;
+
 class WorkOSServiceProviderTest extends LaravelTestCase
 {
     protected $app;
@@ -9,17 +11,95 @@ class WorkOSServiceProviderTest extends LaravelTestCase
     protected function setUp(): void
     {
         $this->app = $this->setupApplication();
+        $this->setDefaultConfig();
+        $this->setupProvider($this->app);
     }
 
-    public function testRegisterWorkOSServiceProviderYieldsExpectedConfig()
+    protected function setDefaultConfig(array $overrides = []): void
     {
-        $this->app["config"]->set("workos.api_key", "pk_secretsauce");
-        $this->app["config"]->set("workos.client_id", "client_pizza");
-        $this->app["config"]->set("workos.api_base_url", "https://workos-hop.com/");
-        $this->setupProvider($this->app);
+        $defaults = [
+            'api_key' => 'pk_test',
+            'client_id' => 'client_test',
+        ];
 
-        $this->assertEquals("pk_secretsauce", \WorkOS\WorkOS::getApiKey());
-        $this->assertEquals("client_pizza", \WorkOS\WorkOS::getClientId());
-        $this->assertEquals("https://workos-hop.com/", \WorkOS\WorkOS::getApiBaseUrl());
+        foreach (array_merge($defaults, $overrides) as $key => $value) {
+            $this->app['config']->set("workos.{$key}", $value);
+        }
+    }
+
+    public function test_register_work_os_service_provider_yields_expected_config()
+    {
+        $this->setDefaultConfig([
+            'api_key' => 'pk_secretsauce',
+            'client_id' => 'client_pizza',
+            'api_base_url' => 'https://workos-hop.com/',
+        ]);
+
+        // Resolve the service to trigger lazy initialization
+        $this->app->make('workos');
+
+        $this->assertEquals('pk_secretsauce', \WorkOS\WorkOS::getApiKey());
+        $this->assertEquals('client_pizza', \WorkOS\WorkOS::getClientId());
+        $this->assertEquals('https://workos-hop.com/', \WorkOS\WorkOS::getApiBaseUrl());
+    }
+
+    public function test_workos_helper_function_returns_work_os_service_instance()
+    {
+        $this->assertInstanceOf(WorkOSService::class, workos());
+    }
+
+    public function test_workos_helper_function_enables_fluent_access()
+    {
+        $this->assertInstanceOf(\WorkOS\UserManagement::class, workos()->userManagement());
+    }
+
+    public function test_it_resolves_service_via_injection_and_configures_sdk()
+    {
+        $service = $this->app->make(WorkOSService::class);
+
+        $this->assertInstanceOf(WorkOSService::class, $service);
+        $this->assertSame($service, $this->app->make('workos'));
+        $this->assertSame($service, workos());
+    }
+
+    public function test_workos_service_resolves_all_supported_services()
+    {
+        $service = workos();
+
+        $this->assertInstanceOf(\WorkOS\AuditLogs::class, $service->auditLogs());
+        $this->assertInstanceOf(\WorkOS\DirectorySync::class, $service->directorySync());
+        $this->assertInstanceOf(\WorkOS\MFA::class, $service->mfa());
+        $this->assertInstanceOf(\WorkOS\Organizations::class, $service->organizations());
+        $this->assertInstanceOf(\WorkOS\Portal::class, $service->portal());
+        $this->assertInstanceOf(\WorkOS\SSO::class, $service->sso());
+        $this->assertInstanceOf(\WorkOS\UserManagement::class, $service->userManagement());
+    }
+
+    public function test_workos_service_caches_service_instances()
+    {
+        $service = workos();
+
+        $userManagement1 = $service->userManagement();
+        $userManagement2 = $service->userManagement();
+
+        $this->assertSame($userManagement1, $userManagement2);
+    }
+
+    public function test_workos_service_throws_exception_for_unsupported_service()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('WorkOS service [unsupportedService] is not supported.');
+
+        $service = workos();
+        $service->unsupportedService();
+    }
+
+    public function test_api_base_url_is_set_when_provided()
+    {
+        $this->setDefaultConfig(['api_base_url' => 'https://custom-api.workos.com/']);
+
+        $this->app->make('workos');
+
+        $this->assertEquals('https://custom-api.workos.com/', \WorkOS\WorkOS::getApiBaseUrl());
     }
 }

--- a/tests/WorkOS/WorkOSServiceProviderTest.php
+++ b/tests/WorkOS/WorkOSServiceProviderTest.php
@@ -121,7 +121,7 @@ class WorkOSServiceProviderTest extends LaravelTestCase
             $className = basename($file, '.php');
 
             // Skip utility classes that aren't services
-            if (in_array($className, ['WorkOS', 'Client', 'Version', 'Resource'])) {
+            if (in_array($className, ['WorkOS', 'Client', 'Version', 'Resource', 'CookieSession'])) {
                 continue;
             }
 


### PR DESCRIPTION
This change introduces Laravel-specific patterns for interacting with WorkOS:

* A WorkOS facade for static access (e.g. `WorkOS::userManagement()->listUsers()`)
* A global `workos()` helper function for fluent access everywhere (e.g. `workos()->userManagement()->listUsers()`)
* `WorkOSService` singleton with cached service instances
* Dependency injection support via service container binding

Additionally, while working on this I noticed a potential performance issue. Previously the service container was setting the API Key and Client ID on every request. The service container now configures the SDK only when requested, and its configuration is cached on subsequent requests.

_this does not break or change any existing client code_.

## Intriguing, tell me more

Throughout Laravel, there are multiple common patterns used to get access to the various services/components of your application. For example, if you're issuing a response, you could either import and use the `Response` Facade directly:

```php
use Illuminate\Support\Facades\Response;
 
Route::get('/users', function () {
    return Response::json([...]);
});
```

Alternatively, you could use a global helper as a one-off:

```php
Route::get('/users', function () {
    return response()->json([...]);
});
```

Or, finally, you could inject the dependency into a function as a typed argument, and it will be automatically resolved by the Service Container:

```php
use Illuminate\Support\Facades\Response;
 
Route::get('/users', function (Response $response) {
    return $response->json([...]);
});
```

This PR updates the code so that we enable similar ergonomics using their usual patterns. For example:

```php
/* Facade version */
use WorkOS\Laravel\Facades\WorkOS;

Route::get('/users', function () {
    return WorkOS::userManagement()->listUsers();
});

/* Helper version */
Route::get('/users', function () {
    return workos()->userManagement()->listUsers();
});

/* Injection version */
use WorkOS\Laravel\Services\WorkOSService;

Route::get('/users', function (WorkOSService $service) {
    return $service->userManagement()->listUsers();
});
```

These are automatically registered immediately upon installing the `workos-php-laravel` package, and make it much, much easier to productively integrate the client into your project.