### PR TITLE
feat!: require workos-php v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": ">=8.2.0",
     "illuminate/contracts": "^11.0|^12.0|^13.0",
     "illuminate/support": "^11.0|^12.0|^13.0",
-    "workos/workos-php": "^6.0.0"
+    "workos/workos-php": "^6.0.0 || ^7.0.1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "php": ">=8.2.0",
     "illuminate/contracts": "^11.0|^12.0|^13.0",
     "illuminate/support": "^11.0|^12.0|^13.0",
-    "workos/workos-php": "^6.0.0 || ^7.0.1"
+    "workos/workos-php": "^7.0.1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=8.2.0",
     "illuminate/contracts": "^12.0|^13.0",
     "illuminate/support": "^12.0|^13.0",
-    "workos/workos-php": "^6.0.0"
+    "workos/workos-php": "^7.0.1"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",

--- a/tests/WorkOS/WorkOSServiceProviderTest.php
+++ b/tests/WorkOS/WorkOSServiceProviderTest.php
@@ -96,7 +96,7 @@ class WorkOSServiceProviderTest extends LaravelTestCase
         $this->assertInstanceOf(\WorkOS\SessionManager::class, $client->sessionManager());
         $this->assertInstanceOf(\WorkOS\Service\SSO::class, $client->sso());
         $this->assertInstanceOf(\WorkOS\Service\UserManagement::class, $client->userManagement());
-        $this->assertInstanceOf(\WorkOS\Vault::class, $client->vault());
+        $this->assertInstanceOf(\WorkOS\Service\Vault::class, $client->vault());
         $this->assertInstanceOf(\WorkOS\WebhookVerification::class, $client->webhookVerification());
         $this->assertInstanceOf(\WorkOS\Service\Webhooks::class, $client->webhooks());
         $this->assertInstanceOf(\WorkOS\Service\Widgets::class, $client->widgets());


### PR DESCRIPTION
Closes https://github.com/workos/workos-php-laravel/issues/102.

The workos-php package was released, but was not reflected here.

**BREAKING CHANGE:** drops support for workos-php v6. v7 moved the Vault service from `\WorkOS\Vault` to `\WorkOS\Service\Vault`, a breaking change that no single class reference can satisfy across both majors, so the constraint is narrowed to `^7.0.1` and the service-provider test asserts against the new namespace.