### PR TITLE
feat!: drop Laravel 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        laravel: ['11.*', '12.*', '13.*']
+        laravel: ['12.*', '13.*']
         exclude:
           - php: '8.2'
             laravel: '13.*'

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "WorkOS PHP Library for Laravel",
   "keywords": [
     "laravel",
-    "laravel 11",
     "laravel 12",
     "laravel 13",
     "workos",
@@ -19,14 +18,14 @@
   ],
   "require": {
     "php": ">=8.2.0",
-    "illuminate/contracts": "^11.0|^12.0|^13.0",
-    "illuminate/support": "^11.0|^12.0|^13.0",
+    "illuminate/contracts": "^12.0|^13.0",
+    "illuminate/support": "^12.0|^13.0",
     "workos/workos-php": "^6.0.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",
     "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
-    "orchestra/testbench": "^9.0|^10.0|^11.0"
+    "orchestra/testbench": "^10.0|^11.0"
   },
   "suggest": {
     "laravel/framework": "For testing"


### PR DESCRIPTION
Laravel 11 has unpatched security issues that are not going to get fixed because the framework is EOL. This PR drops support for it in this package. 